### PR TITLE
Add RUST_SRC_PATH env for rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,14 +20,9 @@
     in
     {
       devShell = forAllSystems ({ system, pkgs, ... }:
-        let
-          rustPlatform = pkgs.makeRustPlatform {
-            inherit (pkgs) rustc cargo;
-          };
-        in
         pkgs.mkShell {
           name = "fsm-shell";
-          RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
           buildInputs = with pkgs; [
             cargo
             rustc


### PR DESCRIPTION
Add a required `RUST_SRC_PATH` env var for folks using `rust-analyzer` in their system and want to get the correct go-to definitions for source lookups etc.

For example, `nix run github:hoverbear-consulting/flake#neovimConfigured src/main.rs` would error with:

```
LSP[rust_analyzer] rust-analyzer failed to load workspace: Failed to find sysroot for Cargo.toml file /home/ana/git/determinatesystems/fsm/Cargo.toml. Is rust-src installed?: can't load stan
dard library from sysroot
/nix/store/w48c38kc769cgjxjq9nr46dqdbgkhs7s-rustc-1.62.1
(discovered via `rustc --print sysroot`)
try installing the Rust source the same way you installed rustc
Press ENTER or type command to continue
```