### PR TITLE
Add aarch64-darwin support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     let
       nameValuePair = name: value: { inherit name value; };
       genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
-      allSystems = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
+      allSystems = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       forAllSystems = f: genAttrs allSystems (system: f {
         inherit system;
@@ -51,7 +51,7 @@
 
               buildInputs = with pkgs; [
                 openssl
-              ];
+              ] ++ pkgs.lib.optionals (system == "aarch64-darwin") (with pkgs.darwin.apple_sdk.frameworks; [ SystemConfiguration ]);
 
               preBuild = ''
                 cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
This PR adds support for `aarch64-darwin` by providing a missing Darwin-specific framework dependency (namely `SystemConfiguration`).