### PR TITLE
Fix `*-darwin` shell with `libiconv` build input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
             codespell
             nixpkgs-fmt
             findutils # for xargs
-          ];
+          ] ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ]);
         });
 
       packages = forAllSystems


### PR DESCRIPTION
The changes originally introduced in #17 fixed `nix build` on Darwin but didn't fix the Nix shell, as indicated by error output from `cargo build` and `cargo run`:

```
= note: ld: library not found for -liconv
```

This PR addresses that by adding `libiconv` to the shell `buildInputs` on Darwin.