### PR TITLE
Add missing dev shell dependency for aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
             codespell
             nixpkgs-fmt
             findutils # for xargs
-          ] ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ]);
+          ] ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv darwin.apple_sdk.frameworks.Security ]);
         });
 
       packages = forAllSystems


### PR DESCRIPTION
Some recent added dependency broke the `nix develop` experience for `aarch64-darwin` (this is just for building `fsm` itself, not for _using_ fsm). It's not clear why this dependency is necessary for `nix develop` shell and not `nix build` but this resolves the issue for now.