### PR TITLE
Revert problematic commit from "init `fsm run` subcommand"

### DIFF
--- a/src/cmds/run.rs
+++ b/src/cmds/run.rs
@@ -47,7 +47,9 @@ impl Run {
 
         tracing::trace!(command = ?nix_develop_command, "Running");
         let nix_develop_exit = nix_develop_command
-            .output()
+            .spawn()
+            .wrap_err("Failed to spawn `nix develop`")?
+            .wait_with_output()
             .await
             .wrap_err("Could not execute `nix develop`")?;
 

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -33,7 +33,9 @@ impl Shell {
 
         tracing::trace!(command = ?nix_develop_command, "Running");
         let nix_develop_exit = nix_develop_command
-            .output()
+            .spawn()
+            .wrap_err("Failed to spawn `nix develop`")?
+            .wait_with_output()
             .await
             .wrap_err("Could not execute `nix develop`")?;
 


### PR DESCRIPTION
Reverts DeterminateSystems/fsm#44

Sorry @cole-h but I didn't actually run it again before merging, and I should have. It looks like both `fsm shell` and `fsm run` are broken:

`fsm shell` never actually puts me into a shell:

```
grahamc@scruffy:~/projects/github.com/DeterminateSystems/fsm/ > ./target/debug/fsm shell
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt
^C
```

and `cargo run` never outputs anything, and I'm not sure if it is running the program:

```
grahamc@scruffy:~/projects/github.com/DeterminateSystems/fsm/ > ./target/debug/fsm run date
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt
grahamc@scruffy:~/projects/github.com/DeterminateSystems/fsm/ > ./target/debug/fsm run cargo build
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt
grahamc@scruffy:~/projects/github.com/DeterminateSystems/fsm/ > 

```