### PR TITLE
Add missing Security framework for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/DeterminateSystems/fsm"
 
+[package.metadata.fsm]
+build-inputs = [ "darwin.apple_sdk.frameworks.Security" ]
+
 [dependencies]
 atty = "0.2"
 cfg-if = "1"


### PR DESCRIPTION
This PR performs a bit of dog fooding, adding a missing Apple framework that un-breaks `fsm run cargo *` in this repo.