### PR TITLE
treewide: fsm -> riff outside of code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,30 +38,30 @@ jobs:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     # Runs clippy as part of the preBuild.
-    - name: Build fsm
-      run: nix build .#packages.x86_64-linux.fsm -L
-    - name: Build fsmStatic
-      run: nix build .#packages.x86_64-linux.fsmStatic -L
-    - name: Create artifact for fsmStatic
+    - name: Build riff
+      run: nix build .#packages.x86_64-linux.riff -L
+    - name: Build riffStatic
+      run: nix build .#packages.x86_64-linux.riffStatic -L
+    - name: Create artifact for riffStatic
       uses: actions/upload-artifact@v3
       with:
-        name: fsm-x86_64-linux
+        name: riff-x86_64-linux
         path: |
-          result/bin/fsm
+          result/bin/riff
 
-  FsmShell:
+  RiffShell:
     needs: Build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Download prebuilt fsm
+    - name: Download prebuilt riff
       uses: actions/download-artifact@v3
       with:
-        name: fsm-x86_64-linux
-    - name: Run `fsm --help`
+        name: riff-x86_64-linux
+    - name: Run `riff --help`
       run: |
-        chmod +x fsm
-        ./fsm --help
+        chmod +x riff
+        ./riff --help
 
   Spelling:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,34 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsm"
-version = "0.1.0"
-dependencies = [
- "atty",
- "cfg-if",
- "clap",
- "color-eyre",
- "eyre",
- "indicatif",
- "itertools",
- "once_cell",
- "os-release",
- "owo-colors",
- "reqwest",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "tokio",
- "tokio-test",
- "tracing",
- "tracing-error",
- "tracing-subscriber",
- "uuid",
- "xdg",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +921,34 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "riff"
+version = "0.1.0"
+dependencies = [
+ "atty",
+ "cfg-if",
+ "clap",
+ "color-eyre",
+ "eyre",
+ "indicatif",
+ "itertools",
+ "once_cell",
+ "os-release",
+ "owo-colors",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber",
+ "uuid",
+ "xdg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "fsm"
+name = "riff"
 version = "0.1.0"
 edition = "2021"
-repository = "https://github.com/DeterminateSystems/fsm"
+repository = "https://github.com/DeterminateSystems/riff"
 
+# FIXME: rename to riff in the "fsm -> riff in code" PR
 [package.metadata.fsm]
 build-inputs = [ "darwin.apple_sdk.frameworks.Security" ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "fsm";
+  description = "riff";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
@@ -59,7 +59,7 @@
           '';
         in
         pkgs.mkShell {
-          name = "fsm-shell";
+          name = "riff-shell";
 
           RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
 
@@ -85,7 +85,7 @@
             };
 
             sharedAttrs = {
-              pname = "fsm";
+              pname = "riff";
               version = "unreleased";
               src = self;
 
@@ -109,17 +109,17 @@
             };
           in
           {
-            fsm = naerskLib.buildPackage
+            riff = naerskLib.buildPackage
               (sharedAttrs // { });
           } // lib.optionalAttrs (system == "x86_64-linux") {
-            fsmStatic = naerskLib.buildPackage
+            riffStatic = naerskLib.buildPackage
               (sharedAttrs // {
                 CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
                 OPENSSL_LIB_DIR = "${pkgs.pkgsStatic.openssl.out}/lib";
                 OPENSSL_INCLUDE_DIR = "${pkgs.pkgsStatic.openssl.dev}";
               });
           } // lib.optionalAttrs (system == "aarch64-linux") {
-            fsmStatic = naerskLib.buildPackage
+            riffStatic = naerskLib.buildPackage
               (sharedAttrs // {
                 CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";
                 OPENSSL_LIB_DIR = "${pkgs.pkgsStatic.openssl.out}/lib";
@@ -127,6 +127,6 @@
               });
           });
 
-      defaultPackage = forAllSystems ({ system, ... }: self.packages.${system}.fsm);
+      defaultPackage = forAllSystems ({ system, ... }: self.packages.${system}.riff);
     };
 }

--- a/src/flake-template.inc
+++ b/src/flake-template.inc
@@ -16,7 +16,7 @@
       devShells = forAllSystems ({{ system, pkgs, ... }}: {{
         default = with pkgs;
           stdenv.mkDerivation {{
-            name = "fsm-shell";
+            name = "riff-shell";
             buildInputs = [ {build_inputs} ] ++ lib.optionals (stdenv.isDarwin) [
               libiconv
             ];


### PR DESCRIPTION
This has the least amount of intrusive changes in order to make it
slightly easier to avoid merge conflicts, as there are still in-flight
PRs at this time.

---

Also doesn't touch the README, since Luc is taking care of that in https://github.com/DeterminateSystems/riff/pull/66.