### PR TITLE
Add missing Security framework dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,16 @@ version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/DeterminateSystems/riff"
 
+[package.metadata.riff.targets.aarch64-apple-darwin]
+build-inputs = [
+  "darwin.apple_sdk.frameworks.Security"
+]
+
+[package.metadata.riff.targets.x86_64-apple-darwin]
+build-inputs = [
+  "darwin.apple_sdk.frameworks.Security"
+]
+
 [dependencies]
 atty = "0.2"
 cfg-if = "1"
@@ -33,13 +43,3 @@ etc-passwd = "0.2"
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-
-[package.metadata.riff.targets.aarch64-apple-darwin]
-build-inputs = [
-  "darwin.apple_sdk.frameworks.Security"
-]
-
-[package.metadata.riff.targets.x86_64-apple-darwin]
-build-inputs = [
-  "darwin.apple_sdk.frameworks.Security"
-]


### PR DESCRIPTION
Just another small bit of dogfooding here. Now that Riff supports target-specific dependencies we can make sure that Riff works to build Riff itself.
