### PR TITLE
Add envrc for flake and Riff

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+use_riff() {
+  watch_file Cargo.toml Cargo.lock
+  eval "$(riff print-dev-env)"
+}
+
+use riff
+use flake .


### PR DESCRIPTION
This PR performs a bit of dogfooding, adding a `use_riff` function to the `.envrc`&mdash;the same function we recommend in the docs&mdash;as well as a `use flake` directive, primarily to automatically load the [`ci-*`](../tree/main/nix/ci.nix) commands into the local env (although having the right `cargo` and such is also a worthy benefit).