### PR TITLE
ci: build x86_64-darwin binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: nix develop --command ci-test-rust
         # run: nix develop -c -- cargo test -- --include-ignored
 
-  Build:
+  BuildX86Linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
             result/bin/riff
 
   RiffShell:
-    needs: Build
+    needs: BuildX86Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
These aren't guaranteed to work (since, unfortunately, macOS does not
appear to support static binaries), but it's somewhat better than
nothing.

---

I didn't change the name of the x86_64-linux job because its name is tied to branch protection. (If I could make it so all `Build*`  actions were required, instead of an exactly-matching `Build`, things would be slightly easier.)