### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[coc@determinate.systems](coc@determinate.systems).
+[coc-grahamc@determinate.systems](coc-grahamc@determinate.systems) or [coc-ana@determinate.systems](coc-ana@determinate.systems) .
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Use the contributor covenant for several reasons:

* It focuses us, as contributors, pledging to make a space safe for participation.
* It highlights how to positively participate in the community **first.** Describing unacceptable behavior after, creating a positive framing.
* It clearly outlines consequences and domains of affect.

Note: @grahamc , could you please ensure the `coc-grahamc@determinate.systems` and `coc-ana@determinate.systems` email points to your and my emails appropriately? We want to have two contacts and have them clearly listed who the recipient is so that if a contact needs to occur the person is aware who will receive the message, and have a second option in case their report relates to the person who would receive the email otherwise.