### PR TITLE
Add 'generate' command to write flake.{nix,lock} to the project directory

### DIFF
--- a/src/cmds/generate.rs
+++ b/src/cmds/generate.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use eyre::eyre;
+
+use crate::flake_generator;
+
+/// Generate a 'flake.nix' file
+///
+/// For example, to create a 'flake.nix' for the project in the
+/// current directory:
+///
+///     $ riff generate
+#[derive(Debug, Args)]
+pub struct Generate {
+    /// The root directory of the project
+    #[clap(long, value_parser)]
+    project_dir: Option<PathBuf>,
+    #[clap(from_global)]
+    disable_telemetry: bool,
+    #[clap(from_global)]
+    offline: bool,
+    /// Write the generated `flake.nix` to stdout.
+    #[clap(long)]
+    stdout: bool,
+}
+
+impl Generate {
+    pub async fn cmd(&self) -> color_eyre::Result<()> {
+        let project_dir = crate::cmds::get_project_dir(&self.project_dir)?;
+
+        let flake_dir = flake_generator::generate_flake_from_project_dir(
+            &project_dir,
+            self.offline,
+            self.disable_telemetry,
+        )
+        .await?;
+
+        if self.stdout {
+            let s = tokio::fs::read_to_string(flake_dir.path().join("flake.nix")).await?;
+            println!("{}", s);
+        } else {
+            for filename in ["flake.nix", "flake.lock"] {
+                let src_path = flake_dir.path().join(filename);
+                let dst_path = project_dir.join(filename);
+
+                if dst_path.exists() {
+                    return Err(eyre!(
+                        "File `{}` already exists, refusing to overwrite.",
+                        dst_path.display()
+                    ));
+                }
+
+                tokio::fs::copy(&src_path, &dst_path).await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,12 +1,25 @@
+mod generate;
 mod print_dev_env;
 mod run;
 mod shell;
 
 use clap::Subcommand;
+use eyre::WrapErr;
+use std::path::PathBuf;
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     Shell(shell::Shell),
     Run(run::Run),
     PrintDevEnv(print_dev_env::PrintDevEnv),
+    Generate(generate::Generate),
+}
+
+pub fn get_project_dir(project_dir: &Option<PathBuf>) -> color_eyre::Result<PathBuf> {
+    let project_dir = match project_dir {
+        Some(dir) => dir.clone(),
+        None => std::env::current_dir().wrap_err("Current working directory was invalid")?,
+    };
+    tracing::debug!("Project directory is '{}'.", project_dir.display());
+    Ok(project_dir)
 }

--- a/src/cmds/print_dev_env.rs
+++ b/src/cmds/print_dev_env.rs
@@ -1,4 +1,4 @@
-//! The `run` subcommand.
+//! The `print-dev-env` subcommand.
 
 use std::{path::PathBuf, process::Stdio};
 
@@ -9,7 +9,7 @@ use tokio::process::Command;
 
 use crate::flake_generator;
 
-/// print shell code that can be sourced by bash to reproduce the riff environment
+/// Print shell code that can be sourced by bash to reproduce the riff environment
 ///
 /// For example, run `cargo build` inside riff:
 ///
@@ -27,8 +27,10 @@ pub struct PrintDevEnv {
 
 impl PrintDevEnv {
     pub async fn cmd(&self) -> color_eyre::Result<Option<i32>> {
+        let project_dir = crate::cmds::get_project_dir(&self.project_dir)?;
+
         let flake_dir = flake_generator::generate_flake_from_project_dir(
-            self.project_dir.clone(),
+            &project_dir,
             self.offline,
             self.disable_telemetry,
         )

--- a/src/cmds/run.rs
+++ b/src/cmds/run.rs
@@ -34,8 +34,10 @@ pub struct Run {
 
 impl Run {
     pub async fn cmd(&self) -> color_eyre::Result<Option<i32>> {
+        let project_dir = crate::cmds::get_project_dir(&self.project_dir)?;
+
         let flake_dir = flake_generator::generate_flake_from_project_dir(
-            self.project_dir.clone(),
+            &project_dir,
             self.offline,
             self.disable_telemetry,
         )

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -20,8 +20,10 @@ pub struct Shell {
 
 impl Shell {
     pub async fn cmd(self) -> color_eyre::Result<Option<i32>> {
+        let project_dir = crate::cmds::get_project_dir(&self.project_dir)?;
+
         let flake_dir = flake_generator::generate_flake_from_project_dir(
-            self.project_dir,
+            &project_dir,
             self.offline,
             self.disable_telemetry,
         )

--- a/src/flake_generator.rs
+++ b/src/flake_generator.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
@@ -13,16 +13,10 @@ use crate::telemetry::Telemetry;
 /// Generates a `flake.nix` by inspecting the specified `project_dir` for supported project types.
 #[tracing::instrument(skip(disable_telemetry))]
 pub async fn generate_flake_from_project_dir(
-    project_dir: Option<PathBuf>,
+    project_dir: &Path,
     offline: bool,
     disable_telemetry: bool,
 ) -> color_eyre::Result<TempDir> {
-    let project_dir = match project_dir {
-        Some(dir) => dir,
-        None => std::env::current_dir().wrap_err("Current working directory was invalid")?,
-    };
-    tracing::debug!("Project directory is '{}'.", project_dir.display());
-
     let registry = DependencyRegistry::new(offline).await?;
     let mut dev_env = DevEnvironment::new(&registry);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,10 @@ Try running it in a shell; for example:
 
             Ok(exit_status_to_exit_code(code))
         }
+        Commands::Generate(generate) => {
+            generate.cmd().await?;
+            Ok(ExitCode::SUCCESS)
+        }
     }
 }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -75,6 +75,7 @@ impl Telemetry {
             Some(Commands::Shell(_)) => Some("shell".to_string()),
             Some(Commands::Run(_)) => Some("run".to_string()),
             Some(Commands::PrintDevEnv(_)) => Some("print-dev-env".to_string()),
+            Some(Commands::Generate(_)) => Some("generate".to_string()),
             None => None,
         };
 


### PR DESCRIPTION
It also has a `--stdout` option to write `flake.nix` to stdout, which may be useful to see what riff is doing.

Unfortunately, `flake.nix` is not pretty-printed, so the output is rather ugly.