### PR TITLE
More registry fixes

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -191,9 +191,18 @@
           ]
         },
         "libudev-sys": {
-          "build-inputs": [
-            "eudev"
-          ]
+          "targets": {
+            "aarch64-linux-unknown-gnu": {
+              "build-inputs": [
+                "eudev"
+              ]
+            },
+            "x86_64-linux-unknown-gnu": {
+              "build-inputs": [
+                "eudev"
+              ]
+            }
+          }
         },
         "libusb1-sys": {
           "build-inputs": [


### PR DESCRIPTION
Most of the `accessibility` category (that we scraped) should be fixed now (with the exception of https://github.com/A11yWatch/crawler, which tries to call `npm` as a part of its `build.rs`, and https://github.com/Taptiive/machineid-rs, which doesn't have an implementation for macOS).