### PR TITLE
flake-template: provide a compatibility shim for older Nix installations

### DIFF
--- a/src/flake-template.inc
+++ b/src/flake-template.inc
@@ -29,5 +29,8 @@
             {ld_library_path}
           }};
       }});
+
+      # Compatibility with older Nix installations that don't check for `devShells.<arch>.default` first.
+      devShell = forAllSystems ({{ system, ... }}: self.devShells.${{system}}.default);
   }};
 }}


### PR DESCRIPTION
Some older versions of Nix may not look for the
`devShells.<arch>.default` output, but it may look for `devShell.<arch>`.

---

Maybe fixes https://github.com/DeterminateSystems/riff/issues/113.