### PR TITLE
Ensure distinct_id can't get leaked on accident

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "os-release",
  "owo-colors",
  "reqwest",
+ "secrecy",
  "semver",
  "serde",
  "serde_json",
@@ -968,6 +969,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "xdg",
+ "zeroize",
 ]
 
 [[package]]
@@ -990,6 +992,16 @@ checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
  "windows-sys",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1630,3 +1642,9 @@ checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1"
 os-release = "0.1"
 owo-colors = "3"
 reqwest = "0.11"
+secrecy = { version = "0.8.0", features = ["serde"] }
 semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
@@ -39,6 +40,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 uuid = { version = "1.1.2", features = [ "v4", "fast-rng", "serde" ]}
 xdg = "2"
+zeroize = "1.5.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 etc-passwd = "0.2"


### PR DESCRIPTION
We do this by using the secrecy crate to ensure the `fmt::Debug` representation of the Telemetry struct redacts the distinct_id field.

---

Because `Uuid` is a foreign type, I had to make a newtype around it in order to implement the marker traits that allows `secrecy::Secret` to do its job.