### PR TITLE
Print underlying error when we fail to detect a project

### DIFF
--- a/src/cmds/print_dev_env.rs
+++ b/src/cmds/print_dev_env.rs
@@ -61,22 +61,17 @@ impl PrintDevEnv {
             .await
         {
             Ok(nix_print_dev_env_exit) => nix_print_dev_env_exit,
-            err @ Err(_) => {
-                let wrapped_err = err
-                    .wrap_err_with(|| {
-                        format!(
-                            "\
-                        Could not execute `{nix_print_dev_env}`. Is `{nix}` installed?\n\n\
-                        Get instructions for installing Nix: {nix_install_url}\n\
-                        Underlying error\
-                        ",
-                            nix_print_dev_env = "nix print-dev-env".cyan(),
-                            nix = "nix".cyan(),
-                            nix_install_url = "https://nixos.org/download.html".blue().underline(),
-                        )
-                    })
-                    .unwrap_err();
-                eprintln!("{wrapped_err:#}");
+            Err(err) => {
+                let err_msg = format!(
+                    "\
+                    Could not execute `{nix_print_dev_env}`. Is `{nix}` installed?\n\n\
+                    Get instructions for installing Nix: {nix_install_url}\
+                    ",
+                    nix_print_dev_env = "nix print-dev-env".cyan(),
+                    nix = "nix".cyan(),
+                    nix_install_url = "https://nixos.org/download.html".blue().underline(),
+                );
+                eprintln!("{err_msg}\n\nUnderlying error:\n{err}", err = err.red());
                 std::process::exit(1);
             }
         };

--- a/src/dev_env.rs
+++ b/src/dev_env.rs
@@ -97,23 +97,17 @@ impl<'a> DevEnvironment<'a> {
 
         let cargo_metadata_output = match cargo_metadata_command.output().await {
             Ok(output) => output,
-            err @ Err(_) => {
-                let wrapped_err = err
-                    .wrap_err_with(|| {
-                        format!(
-                            "\
-                        Could not execute `{cargo_metadata}`. Is `{cargo}` installed?\n\n\
-                        Get instructions for installing Cargo: {rust_install_url}\n\
-                        Underlying error\
+            Err(err) => {
+                let err_msg = format!(
+                    "\
+                    Could not execute `{cargo_metadata}`. Is `{cargo}` installed?\n\n\
+                    Get instructions for installing Cargo: {rust_install_url}\
                     ",
-                            cargo_metadata = "cargo metadata".cyan(),
-                            cargo = "cargo".cyan(),
-                            rust_install_url =
-                                "https://www.rust-lang.org/tools/install".blue().underline()
-                        )
-                    })
-                    .unwrap_err();
-                eprintln!("{wrapped_err:#}");
+                    cargo_metadata = "cargo metadata".cyan(),
+                    cargo = "cargo".cyan(),
+                    rust_install_url = "https://www.rust-lang.org/tools/install".blue().underline()
+                );
+                eprintln!("{err_msg}\n\nUnderlying error:\n{err}", err = err.red());
                 std::process::exit(1);
             }
         };

--- a/src/flake_generator.rs
+++ b/src/flake_generator.rs
@@ -109,22 +109,17 @@ pub async fn generate_flake_from_project_dir(
 
     let nix_lock_exit = match nix_lock_command.output().await {
         Ok(nix_lock_exit) => nix_lock_exit,
-        err @ Err(_) => {
-            let wrapped_err = err
-                .wrap_err_with(|| {
-                    format!(
-                        "\
-                    Could not execute `{nix_lock}`. Is `{nix}` installed?\n\n\
-                    Get instructions for installing Nix: {nix_install_url}\n\
-                    Underlying error\
-                    ",
-                        nix_lock = "nix flake lock".cyan(),
-                        nix = "nix".cyan(),
-                        nix_install_url = "https://nixos.org/download.html".blue().underline(),
-                    )
-                })
-                .unwrap_err();
-            eprintln!("{wrapped_err:#}");
+        Err(err) => {
+            let err_msg = format!(
+                "\
+                Could not execute `{nix_lock}`. Is `{nix}` installed?\n\n\
+                Get instructions for installing Nix: {nix_install_url}\
+                ",
+                nix_lock = "nix flake lock".cyan(),
+                nix = "nix".cyan(),
+                nix_install_url = "https://nixos.org/download.html".blue().underline(),
+            );
+            eprintln!("{err_msg}\n\nUnderlying error:\n{err}", err = err.red());
             std::process::exit(1);
         }
     };

--- a/src/flake_generator.rs
+++ b/src/flake_generator.rs
@@ -28,20 +28,16 @@ pub async fn generate_flake_from_project_dir(
 
     match dev_env.detect(&project_dir).await {
         Ok(_) => {}
-        err @ Err(_) => {
-            let wrapped_err = err
-                .wrap_err_with(|| {
-                    format!(
-                        "\
-                            `{colored_project_dir}` doesn't contain a project recognized by Riff.\n\
-                            Try running `{riff_shell}` in a Rust project directory.\
-                    ",
-                        colored_project_dir = &project_dir.display().to_string().green(),
-                        riff_shell = "riff shell".cyan(),
-                    )
-                })
-                .unwrap_err();
-            eprintln!("{wrapped_err}");
+        Err(err) => {
+            let err_msg = format!(
+                "\
+                `{colored_project_dir}` doesn't contain a project recognized by Riff.\n\
+                Try running `{riff_shell}` in a Rust project directory.\
+                ",
+                colored_project_dir = &project_dir.display().to_string().green(),
+                riff_shell = "riff shell".cyan(),
+            );
+            eprintln!("{err_msg}\n\nUnderlying error:\n{err}", err = err.red());
             std::process::exit(1);
         }
     };

--- a/src/nix_dev_env.rs
+++ b/src/nix_dev_env.rs
@@ -63,22 +63,17 @@ pub async fn get_raw_nix_dev_env(flake_dir: &Path) -> color_eyre::Result<String>
         .await
     {
         Ok(nix_command_exit) => nix_command_exit,
-        err @ Err(_) => {
-            let wrapped_err = err
-                .wrap_err_with(|| {
-                    format!(
-                        "\
-                        Could not execute `{nix_print_dev_env}`. Is `{nix}` installed?\n\n\
-                        Get instructions for installing Nix: {nix_install_url}\n\
-                        Underlying error\
-                        ",
-                        nix_print_dev_env = "nix print-dev-env".cyan(),
-                        nix = "nix".cyan(),
-                        nix_install_url = "https://nixos.org/download.html".blue().underline(),
-                    )
-                })
-                .unwrap_err();
-            eprintln!("{wrapped_err:#}");
+        Err(err) => {
+            let err_msg = format!(
+                "\
+                Could not execute `{nix_print_dev_env}`. Is `{nix}` installed?\n\n\
+                Get instructions for installing Nix: {nix_install_url}\
+                ",
+                nix_print_dev_env = "nix print-dev-env".cyan(),
+                nix = "nix".cyan(),
+                nix_install_url = "https://nixos.org/download.html".blue().underline(),
+            );
+            eprintln!("{err_msg}\n\nUnderlying error:\n{err}", err = err.red());
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
e.g.:

![image](https://user-images.githubusercontent.com/28582702/189231037-f487b3be-e908-460e-a176-b8d58a2f9a73.png)

![image](https://user-images.githubusercontent.com/28582702/189230726-e1a729cb-8713-425b-9737-6c6f2c300ea2.png)

---

I'm not set on the "red-ify all the errors", but I think it looks good.

One issue with the current approach is that we duplicate the error from https://github.com/DeterminateSystems/riff/blob/895037519e9fcc1bdb6e709d4ffa34ed71851c96/src/dev_env.rs#L71 (due to https://github.com/DeterminateSystems/riff/blob/895037519e9fcc1bdb6e709d4ffa34ed71851c96/src/flake_generator.rs#L36).

Could be addressed by slightly changing the wording so we get:

![image](https://user-images.githubusercontent.com/28582702/189231716-2ca16aa5-c6eb-4b50-9b8c-5765f97f1ae4.png)

instead of 

![image](https://user-images.githubusercontent.com/28582702/189231786-40cd369f-2ff4-433e-993a-0dd05bf10d5a.png)

Suggestions welcome.