### PR TITLE
flake: override -> overrideMain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
               doCheck = true;
 
-              override = { preBuild ? "", ... }: {
+              overrideMain = { preBuild ? "", ... }: {
                 preBuild = preBuild + ''
                   logRun "cargo clippy --all-targets --all-features -- -D warnings"
                 '';


### PR DESCRIPTION
overrideMain only applies for the main crate, which is a Good Thing, especially if we want to add things that may not apply for dependencies down the line.

---

Closes https://github.com/DeterminateSystems/riff/issues/14.