### PR TITLE
flake: make `riffStatic` the default package for linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,11 @@
               });
           });
 
-      defaultPackage = forAllSystems ({ system, ... }: self.packages.${system}.riff);
+      defaultPackage = forAllSystems ({ system, ... }:
+        if (system == "x86_64-linux" || system == "aarch64-linux") then
+          self.packages.${system}.riffStatic
+        else
+          self.packages.${system}.riff
+      );
     };
 }


### PR DESCRIPTION
We distribute the static binary, so `nix build
github:determinatesystems/riff` should build the same thing by default.