### PR TITLE
buildkite: specify agent tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,8 @@
 steps:
   - label: BuildAarch64Darwin
+    agents:
+      mac: 1
+      system: aarch64-darwin
     command:
       - nix --extra-experimental-features "nix-command flakes" build .#packages.aarch64-darwin.riff -L
       - cp result/bin/riff ./riff-aarch64-darwin


### PR DESCRIPTION
We don't want to try to build aarch64 on our x86 macs.