### PR TITLE
registry: add runtime inputs for openssl-sys

### DIFF
--- a/registry/format.sh
+++ b/registry/format.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 cd "$(dirname "$0")"
 
 jq -S < registry.json > registry.next.json

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -234,9 +234,19 @@
                 "darwin.apple_sdk.frameworks.Security"
               ]
             },
+            "aarch64-unknown-linux-gnu": {
+              "runtime-inputs": [
+                "openssl"
+              ]
+            },
             "x86_64-apple-darwin": {
               "build-inputs": [
                 "darwin.apple_sdk.frameworks.Security"
+              ]
+            },
+            "x86_64-unknown-linux-gnu": {
+              "runtime-inputs": [
+                "openssl"
               ]
             }
           }


### PR DESCRIPTION
`cargo run` didn't work for me without `openssl` in runtime inputs
didn't test with the registry, but adding `runtime-inputs = ["openssl"]` to `package.metadata.riff` fixes the issue for me