### PR TITLE
registry: set RUST_SRC_PATH for rust-analyzer

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -6,7 +6,10 @@
           "rustc",
           "cargo",
           "rustfmt"
-        ]
+        ],
+        "environment-variables": {
+          "RUST_SRC_PATH": "${rustPlatform.rustLibSrc}"
+        }
       },
       "dependencies": {
         "alsa-sys": {


### PR DESCRIPTION
this should fix https://github.com/DeterminateSystems/riff/issues/126
alternative to https://github.com/DeterminateSystems/riff/pull/171, the downside is that we would pull one extra package by default