### PR TITLE
registry: s/linux-unknown/unknown-linux/g

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "alsa-sys": {
           "targets": {
-            "aarch64-linux-unknown-gnu": {
+            "aarch64-unknown-linux-gnu": {
               "build-inputs": [
                 "alsa-lib"
               ]
             },
-            "x86_64-linux-unknown-gnu": {
+            "x86_64-unknown-linux-gnu": {
               "build-inputs": [
                 "alsa-lib"
               ]
@@ -25,7 +25,7 @@
         },
         "ash": {
           "targets": {
-            "aarch64-linux-unknown-gnu": {
+            "aarch64-unknown-linux-gnu": {
               "build-inputs": [
                 "vulkan-loader",
                 "vulkan-tools",
@@ -36,7 +36,7 @@
                 "vulkan-loader"
               ]
             },
-            "x86_64-linux-unknown-gnu": {
+            "x86_64-unknown-linux-gnu": {
               "build-inputs": [
                 "vulkan-loader",
                 "vulkan-tools",
@@ -201,12 +201,12 @@
         },
         "libudev-sys": {
           "targets": {
-            "aarch64-linux-unknown-gnu": {
+            "aarch64-unknown-linux-gnu": {
               "build-inputs": [
                 "eudev"
               ]
             },
-            "x86_64-linux-unknown-gnu": {
+            "x86_64-unknown-linux-gnu": {
               "build-inputs": [
                 "eudev"
               ]
@@ -396,12 +396,12 @@
         },
         "wayland-sys": {
           "targets": {
-            "aarch64-linux-unknown-gnu": {
+            "aarch64-unknown-linux-gnu": {
               "build-inputs": [
                 "wayland"
               ]
             },
-            "x86_64-linux-unknown-gnu": {
+            "x86_64-unknown-linux-gnu": {
               "build-inputs": [
                 "wayland"
               ]
@@ -415,7 +415,7 @@
                 "darwin.apple_sdk.frameworks.QuartzCore"
               ]
             },
-            "aarch64-linux-unknown-gnu": {
+            "aarch64-unknown-linux-gnu": {
               "environment-variables": {
                 "ALSA_PLUGIN_DIR": "${pkgs.symlinkJoin { name = \"merged-alsa-plugins\"; paths = with pkgs; [ alsaPlugins pipewire.lib ]; }}/lib/alsa-lib"
               },
@@ -438,7 +438,7 @@
                 "darwin.apple_sdk.frameworks.QuartzCore"
               ]
             },
-            "x86_64-linux-unknown-gnu": {
+            "x86_64-unknown-linux-gnu": {
               "environment-variables": {
                 "ALSA_PLUGIN_DIR": "${pkgs.symlinkJoin { name = \"merged-alsa-plugins\"; paths = with pkgs; [ alsaPlugins pipewire.lib ]; }}/lib/alsa-lib"
               },


### PR DESCRIPTION
{aarch64,x86_64}-linux-unknown-gnu are not real targets
https://doc.rust-lang.org/nightly/rustc/platform-support.html