### PR TITLE
pass through $SHELL

### DIFF
--- a/src/nix_dev_env.rs
+++ b/src/nix_dev_env.rs
@@ -102,6 +102,7 @@ pub async fn run_in_dev_env(
             "NIX_LOG_FD",
             "NIX_REMOTE",
             "PPID",
+            "SHELL",
             "SHELLOPTS",
             "SSL_CERT_FILE",
             "TEMP",


### PR DESCRIPTION
https://github.com/NixOS/nix/commit/27be54ca533933db8c3e0cde4b213abf10dd5237

this fixes the issue where my prompt (fish + starship) gets jumbled up if I `riff shell` in a riff shell

before:
```
~/riff on  main 
❯ result/bin/riff shell
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt

~/riff on  main via  impure (riff-shell) 
❯ result/bin/riff shell
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt

\[\]~/riff\[\] on \[\] \[\]\[\]main\[\] via \[\] \[\]\[\]impure\[\]\[\] (\[\]\[\]riff-shell\[\]\[\])\[\] 
\[\]❯\[\] 
```

after:
```
~/riff on  shell 
❯ result/bin/riff shell
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt

~/riff on  shell via  impure (riff-shell) 
❯ result/bin/riff shell
✓ 🦀 rust: cargo, openssl, pkg-config, rustc, rustfmt

~/riff on  shell via  impure (riff-shell) 
❯ 
```