### PR TITLE
registry: remove zstd-sys entry

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -504,12 +504,6 @@
           "native-build-inputs": [
             "cmake"
           ]
-        },
-        "zstd-sys": {
-          "build-inputs": [
-            "zlib",
-            "clang"
-          ]
         }
       }
     }


### PR DESCRIPTION
AFAIW `zstd-sys` doesn't depend on zlib or clang